### PR TITLE
fix deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Coding
 package main
 
 import (
-	"github.com/codegangsta/cli"
 	"github.com/kawamuray/prometheus-exporter-harness/harness"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/urfave/cli"
 )
 
 type collector struct{}

--- a/example/main.go
+++ b/example/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/codegangsta/cli"
 	"github.com/kawamuray/prometheus-exporter-harness/harness"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/urfave/cli"
 )
 
 type collector struct{}

--- a/harness/exporter.go
+++ b/harness/exporter.go
@@ -3,8 +3,8 @@ package harness
 import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
-	"github.com/codegangsta/cli"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/urfave/cli"
 	"net/http"
 	"time"
 )

--- a/harness/main.go
+++ b/harness/main.go
@@ -40,5 +40,8 @@ func MakeApp(opts *ExporterOpts) *cli.App {
 }
 
 func Main(opts *ExporterOpts) {
-	MakeApp(opts).Run(os.Args)
+	err := MakeApp(opts).Run(os.Args)
+	if err != nil {
+		os.Exit(1)
+	}
 }

--- a/harness/main.go
+++ b/harness/main.go
@@ -1,7 +1,8 @@
 package harness
 
 import (
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
+	"os"
 )
 
 func MakeApp(opts *ExporterOpts) *cli.App {
@@ -39,5 +40,5 @@ func MakeApp(opts *ExporterOpts) *cli.App {
 }
 
 func Main(opts *ExporterOpts) {
-	MakeApp(opts).RunAndExitOnError()
+	MakeApp(opts).Run(os.Args)
 }


### PR DESCRIPTION
The warning message is:

```
DEPRECATED cli.App.RunAndExitOnError.  This is an error in the application.  Please contact the distributor of this application if this is not you.  See https://github.com/urfave/cli/blob/master/CHANGELOG.md#deprecated-cli-app-runandexitonerror
```

Exit code example is here:
https://github.com/urfave/cli/blob/c20f912780127757faee8fd4ccafe6fcd02b7ec7/README.md#exit-code

However, It seems that there's nothing to change in `exporter.go func main`.
Because if an error occurred, calling `log.Fatal`.
`log.Fatal` has been implemented `os.Exit(1)`.
